### PR TITLE
Fix missing image

### DIFF
--- a/hardware.yml
+++ b/hardware.yml
@@ -1,5 +1,5 @@
 - name: Speakers or headphones
-  img: speakers-headphones
+  img: headphones-speaker
   url: http://thepihut.com/products/mini-portable-speaker-for-the-raspberry-pi
 - name: 2 x female-to-female jumper wires
   img: jumper-female-to-female


### PR DESCRIPTION
Based on https://github.com/raspberrypilearning/gpio-music-box/blob/master/hardware.yml (where the image _isn't_ missing)